### PR TITLE
Fix Struct Returns Example

### DIFF
--- a/docs/cairo/examples/struct_returns.md
+++ b/docs/cairo/examples/struct_returns.md
@@ -83,54 +83,34 @@ end
 ```
 `struct_returns_UserAnalyst.cairo` below:
 ```sh
-import pytest
-import asyncio
-from starkware.starknet.testing.starknet import Starknet
+%lang starknet
 
-@pytest.fixture(scope='module')
-def event_loop():
-    return asyncio.new_event_loop()
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from contracts.struct_returns_UserDatabase import User
 
-@pytest.fixture(scope='module')
-async def contract_factory():
-    starknet = await Starknet.empty()
-    analyst = await starknet.deploy(
-        "contracts/struct_returns_UserAnalyst.cairo")
-    database = await starknet.deploy(
-        "contracts/struct_returns_UserDatabase.cairo")
-    return starknet, analyst, database
+# This makes UserAnalyst (this contract) aware of UserDatabase.
+@contract_interface
+namespace UserDatabase:
+    func query_user(user_id : felt) -> (user_stats : User):
+    end
+end
 
-@pytest.mark.asyncio
-async def test_contract(contract_factory):
-    starknet, analyst, database = contract_factory
-
-    USER_ID = 43
-    UP = 200
-    DOWN = 32
-    RANK = 17
-    # Call a function.
-    await database.register_user(
-        user_id=USER_ID,
-        upvotes=UP,
-        downvotes=DOWN,
-        rank=RANK).invoke()
-
-    # Ask the analyst contract to fetch-and-score the user.
-    # It will receive a struct containing user data.
-    response = await analyst.score_user(
-        database.contract_address, USER_ID).call()
-
-    assert response.result.user_score == UP - DOWN
-
-    response = await database.query_user(user_id=USER_ID).invoke()
-    # First capture the result of the call. In the contract the
-    # name of the returned value is 'user_stats'.
-    user = response.result.user_stats
-    # The type of 'user_stats' is a a struct defined in the contract.
-    # The struct member values can be accessed by name as follows.
-    assert user.upvotes == UP
-    assert user.downvotes == DOWN
-    assert user.rank == RANK
+@view
+func score_user{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr
+    }(
+        database_address : felt,
+        user_id : felt
+    ) -> (
+        user_score : felt
+    ):
+    # Query stats of user
+    let (user_stats) = UserDatabase.query_user(database_address, user_id)
+    let user_score = user_stats.upvotes - user_stats.downvotes
+    return (user_score)
+end
 
 
 ```


### PR DESCRIPTION
Hi,

First and foremost, thanks for the tutorial! It's helping me a lot in understanding Cairo. I was trying to do the [Struct Returns](https://perama-v.github.io/cairo/examples/struct_returns/) example and I noticed that the code for `struct_returns_UserAnalyst.cairo` is the same as the `test_struct_returns.py`.

<img width="797" alt="image" src="https://user-images.githubusercontent.com/35031356/147743493-b1d1eec8-11f1-4d2b-88bd-565a33822a50.png">
<img width="797" alt="image" src="https://user-images.githubusercontent.com/35031356/147743508-2efac4dc-3b47-49fc-98b1-3aef2a3a448c.png">

I was able to recreate the code for it (thanks to your other examples!), would it be possible for me to merge a PR? Thanks and have a nice day!